### PR TITLE
allow strings with ssml tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,6 +433,19 @@ Speech.prototype.sub = function (alias, word) {
 };
 
 /**
+ * This method lets the user provide a saying that won't have ssml tags escaped.  Use this if you want to pass an ssml string directly 
+ * @param saying
+ * If quotes are needed in the string, use double quotes within single quotes or template literal strings
+ * @returns {Speech}
+ */
+Speech.prototype.sayWithSSML = function (saying) {
+    this._present(saying, "The saying provided to Speech#sayWithSSML(..) was null or undefined.");
+    this._elements.push(saying);
+    return this;
+}
+
+
+/**
  * This method validates if the value exists in the list of values
  * @param value
  * @param listOfValues

--- a/test/speech_test.js
+++ b/test/speech_test.js
@@ -166,6 +166,13 @@ describe('Speech', function () {
 
         });
 
+        describe('sayWithSSML', function() {
+            it('should push strings with ssml tags in them into the speech object', function() {
+                speech.sayWithSSML('we should all <w role="amazon:VB">read</w> more')
+                assert.equal(speech.ssml(), '<speak>we should all <w role="amazon:VB">read</w> more</speak>')
+            })
+        });
+
         describe('spellSlowly', function () {
 
             it('should build a spell slowly tag', function () {


### PR DESCRIPTION
👋  Thanks for creating an awesome library.  I have a need for entering ssml strings into the speech object.  I use randomized phrases in most Alexa skills and sometimes need the ability to put ssml in those strings directly.   Without this, I'd have to build each random option using several `speech` commands which isn't ideal.  Happy to update if you think an alternative approach is more suitable.